### PR TITLE
Update Elasticsearch and mapping

### DIFF
--- a/create_index.sh
+++ b/create_index.sh
@@ -1,11 +1,12 @@
 echo "Downloading Geonames gazetteer..."
-#wget http://download.geonames.org/export/dump/allCountries.zip
+wget http://download.geonames.org/export/dump/allCountries.zip
 echo "Unpacking Geonames gazetteer..."
-#unzip allCountries.zip
+unzip allCountries.zip
 
 echo "Starting Docker container and data volume..."
-sudo docker run -d -p 127.0.0.1:9200:9200 -v $PWD/geonames_index/:/usr/share/elasticsearch/data elasticsearch:5.1.2
-sleep 10s
+sudo docker run -d -p 127.0.0.1:9200:9200 -v $PWD/geonames_index/:/usr/share/elasticsearch/data elasticsearch:5.5.2
+
+sleep 10
 
 echo "Creating mappings for the fields in the Geonames index..."
 curl -XPUT 'localhost:9200/geonames' -H 'Content-Type: application/json' -d @geonames_mapping.json

--- a/geonames_mapping.json
+++ b/geonames_mapping.json
@@ -9,7 +9,7 @@
           "geonameid" : {"type" : "text", "index":    "not_analyzed"},
           "name" : {"type" : "text"},
           "asciiname" : {"type" : "text"},
-          "alternativenames" : {"type" : "text"},
+          "alternativenames" : {"type" : "text", "similarity" : "boolean"},
           "coordinates" : {"type" : "geo_point"},
           "feature_class" :  {"type" : "text", "index":    "not_analyzed"},
           "feature_code" : {"type" : "text", "index":    "not_analyzed"},


### PR DESCRIPTION
This PR has three components:

- Switch to the official Elasticsearch Python library to support new Elasticsearch version
- Split the geonames `alternativenames` field into a list, rather than one big string
- Use a boolean matching score for `alternativenames`, which doesn't penalize it for its length as tf-idf does. (We generally prefer results with longer `alternativenames` fields